### PR TITLE
Bump simple-get-opt upper constraint to allow 0.3.

### DIFF
--- a/test-lib.cabal
+++ b/test-lib.cabal
@@ -21,7 +21,7 @@ library
                        process               >=1.4 && <1.7,
                        containers            >=0.5 && <0.7,
                        HUnit                 >= 1.3.0 && < 1.7,
-                       simple-get-opt        >= 0.2.0 && < 0.3,
+                       simple-get-opt        >= 0.2.0 && < 0.4,
                        test-framework        >= 0.8.0 && < 0.9,
                        test-framework-hunit  >= 0.3.0 && < 0.4
 


### PR DESCRIPTION
Needed to match simple-get-opt to allow builds of the crucible-test-runner.